### PR TITLE
feat: Configure email backend for SMTP

### DIFF
--- a/devathon/settings.py
+++ b/devathon/settings.py
@@ -165,5 +165,5 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = 'stefano20033@gmail.com'
-EMAIL_HOST_PASSWORD = 'fynl zjhq mycd qlly'
+EMAIL_HOST_USER = 'Correo aqui'
+EMAIL_HOST_PASSWORD = 'clave aqui'

--- a/devathon/settings.py
+++ b/devathon/settings.py
@@ -160,3 +160,10 @@ AUTH_USER_MODEL = 'usuarios.Cliente'  # Asegúrate de que esto esté configurado
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = 'stefano20033@gmail.com'
+EMAIL_HOST_PASSWORD = 'fynl zjhq mycd qlly'

--- a/devathon/urls.py
+++ b/devathon/urls.py
@@ -17,11 +17,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenRefreshView
-from .views import MyTokenObtainPairView  # Asegúrate de importar la vista personalizada
+from .views import MyTokenObtainPairView,PasswordResetRequestAPI, PasswordResetConfirmAPI  # Asegúrate de importar la vista personalizada
 
 urlpatterns = [
     path('api/token/', MyTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/password_reset/', PasswordResetRequestAPI.as_view(), name='password_reset'),
+    path('api/password_reset_confirm/', PasswordResetConfirmAPI.as_view(), name='password_reset_confirm'),
     path('admin/', admin.site.urls),
     path('', include('usuarios.urls')),
     path('', include('empleados.urls')),

--- a/devathon/views.py
+++ b/devathon/views.py
@@ -2,6 +2,25 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.views import TokenObtainPairView
 from django.contrib.auth import authenticate  # Importa authenticate
 from rest_framework import serializers
+from rest_framework.permissions import AllowAny
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.core.mail import send_mail
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import force_bytes, force_str
+from django.contrib.auth.models import User
+from django.conf import settings
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from django.urls import reverse
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.template.loader import render_to_string
+from django.core.mail import send_mail
+
+
+User = get_user_model()
 
 class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
     @classmethod
@@ -36,3 +55,118 @@ class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
 
 class MyTokenObtainPairView(TokenObtainPairView):
     serializer_class = MyTokenObtainPairSerializer
+
+
+class PasswordResetRequestAPI(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        email = request.data.get('email')
+        user = User.objects.filter(correo_electronico=email).first()
+        if user:
+            uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+            token = default_token_generator.make_token(user)
+            reset_url = request.build_absolute_uri(
+                reverse('password_reset_confirm') + f"?uid={uidb64}&token={token}"
+            )
+
+            # Genera el cuerpo del correo electrónico directamente en el código
+            email_body = f"""
+            Hola,
+
+            Recibimos una solicitud para restablecer tu contraseña. Puedes hacerlo a través del siguiente enlace:
+
+            {reset_url}
+
+            Si no solicitaste este cambio, puedes ignorar este correo.
+
+            Gracias,
+            El equipo de soporte
+            """
+            
+            send_mail(
+                'Password Reset Request',
+                email_body,
+                'noreply@example.com',
+                [email],
+                fail_silently=False,
+            )
+            return Response({'message': 'Password reset email has been sent.'}, status=status.HTTP_200_OK)
+        return Response({'error': 'Email not found'}, status=status.HTTP_400_BAD_REQUEST)
+
+
+
+class PasswordResetConfirmAPI(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        uidb64 = request.data.get('uid')
+        token = request.data.get('token')
+        new_password = request.data.get('new_password')
+
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            user = None
+
+        if user is not None and default_token_generator.check_token(user, token):
+            user.set_password(new_password)
+            user.save()
+            return Response({'message': 'Password has been reset.'}, status=status.HTTP_200_OK)
+        return Response({'error': 'Invalid token or user ID'}, status=status.HTTP_400_BAD_REQUEST)
+    permission_classes = [AllowAny]  # Permitir acceso sin autenticación
+
+    def post(self, request):
+        uidb64 = request.data.get('uid')
+        token = request.data.get('token')
+        new_password = request.data.get('new_password')
+
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))  # Cambia force_text a force_str
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            user = None
+
+        if user is not None and default_token_generator.check_token(user, token):
+            user.set_password(new_password)
+            user.save()
+            return Response({'message': 'Password has been reset.'}, status=status.HTTP_200_OK)
+        return Response({'error': 'Invalid token or user ID'}, status=status.HTTP_400_BAD_REQUEST)
+    permission_classes = [AllowAny]  # Permitir acceso sin autenticación
+
+    def post(self, request):
+        uidb64 = request.data.get('uid')
+        token = request.data.get('token')
+        new_password = request.data.get('new_password')
+
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))  # Cambia force_text a force_str
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            user = None
+
+        if user is not None and default_token_generator.check_token(user, token):
+            user.set_password(new_password)
+            user.save()
+            return Response({'message': 'Password has been reset.'}, status=status.HTTP_200_OK)
+        return Response({'error': 'Invalid token or user ID'}, status=status.HTTP_400_BAD_REQUEST)
+
+    permission_classes = [AllowAny]  # Permitir acceso sin autenticación
+
+    def post(self, request):
+        uidb64 = request.data.get('uid')
+        token = request.data.get('token')
+        new_password = request.data.get('new_password')
+
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))  # Cambia force_text a force_str
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            user = None
+
+        if user is not None and default_token_generator.check_token(user, token):
+            user.set_password(new_password)
+            user.save()
+            return Response({'message': 'Password has been reset.'}, status=status.HTTP_200_OK)
+        return Response({'error': 'Invalid token or user ID'}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Update `devathon/settings.py` to configure the email backend for SMTP. Set the `EMAIL_BACKEND` to `'django.core.mail.backends.smtp.EmailBackend'` and specify the SMTP server details such as `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USE_TLS`, `EMAIL_HOST_USER`, and `EMAIL_HOST_PASSWORD`.